### PR TITLE
fix(view): page mask after photoswipe close

### DIFF
--- a/assets/js/pswp.js
+++ b/assets/js/pswp.js
@@ -43,7 +43,7 @@ class Gallery {
             });
 
         // 绑定事件
-        $($root).on("click", $selector, (e) => {
+        $($root).find($selector).on("click", (e) => {
             this.open(e.target);
         });
     }


### PR DESCRIPTION
根据jqeury官方的文档：
A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
jquery的on方法的第三个参数仅用于触发事件的时候进行一个筛选。
因此把事件绑定在Article组件上会导致重复触发激活大图模式的事件（